### PR TITLE
F90 cooling

### DIFF
--- a/LibHR/Utils/APE_smearing.c
+++ b/LibHR/Utils/APE_smearing.c
@@ -36,9 +36,8 @@ void APE_smearing(double smear_val, int Nsmear){
     int mu, nu, mid, midpmu, midpnu, midmnu, midpmumnu;
     suNg v, vout, vtmp;
     
-    double sm1 = 1.; //- smear_val;  // ( 1 - \alpha )
-    double sm2 = smear_val; /// 4. ; // ( \alpha \ 6 )
-                                  
+    double sm1 = 1. - smear_val;  // ( 1 - \alpha )
+    double sm2 = smear_val / 6. ; // ( \alpha \ 6 )
     
     suNg_field *u_gauge_tmp = alloc_gfield(&glattice);
     u_gauge_APE = alloc_gfield(&glattice);
@@ -102,9 +101,11 @@ void APE_smearing(double smear_val, int Nsmear){
                     project_to_suNg(&vout); // Project to the group manifold
                     
                     #ifdef GAUGE_SPN
-                    cooling_SPN(&v, &vout, &vtmp, 6); // max Re Tr(U V^+)
+                    cooling_SPN(&v, &vout, &vtmp, 5); // max Re Tr(U V^+)
                     *pu_gauge_tmp(mid, mu) = v;
+                    
                     #else
+                    
                     *pu_gauge_tmp(mid, mu) = vout;
                     
                     #endif

--- a/LibHR/Utils/APE_smearing.c
+++ b/LibHR/Utils/APE_smearing.c
@@ -36,8 +36,9 @@ void APE_smearing(double smear_val, int Nsmear){
     int mu, nu, mid, midpmu, midpnu, midmnu, midpmumnu;
     suNg v, vout, vtmp;
     
-    double sm1 = 1. - smear_val;  // ( 1 - \alpha )
-    double sm2 = smear_val / 6. ; // ( \alpha \ 6 )
+    double sm1 = 1.; //- smear_val;  // ( 1 - \alpha )
+    double sm2 = smear_val; /// 4. ; // ( \alpha \ 6 )
+                                  
     
     suNg_field *u_gauge_tmp = alloc_gfield(&glattice);
     u_gauge_APE = alloc_gfield(&glattice);
@@ -101,11 +102,9 @@ void APE_smearing(double smear_val, int Nsmear){
                     project_to_suNg(&vout); // Project to the group manifold
                     
                     #ifdef GAUGE_SPN
-                    cooling_SPN(&v, &vout, &vtmp, 5); // max Re Tr(U V^+)
+                    cooling_SPN(&v, &vout, &vtmp, 6); // max Re Tr(U V^+)
                     *pu_gauge_tmp(mid, mu) = v;
-                    
                     #else
-                    
                     *pu_gauge_tmp(mid, mu) = vout;
                     
                     #endif

--- a/LibHR/Utils/suN_utils.c
+++ b/LibHR/Utils/suN_utils.c
@@ -470,23 +470,22 @@ void cooling_SPN(suNg* g_out, suNg* g_in, suNg* g_tilde, int cooling){
     _suNg_expand( S, *g_in);
         
     for (int nbcool=0;nbcool<cooling;nbcool++){
-        //_suNgfull_times_suNgfull_dagger(B, S, U_tilde);
+        
         _suNgfull_dagger_times_suNgfull(B, U_tilde, S);
         
         //print the B matrix for debug
-        /*
-        lprintf("MAIN", 0, "Matrix B = S * U_tilde^dagger before cooling step %d:\n", nbcool);
+        
+        lprintf("DEBUG", 2, "Matrix B = S * U_tilde^dagger before cooling step %d:\n", nbcool);
         for (int i=0;i<NG;i++){
             for (int j=0;j<NG;j++){
-                lprintf("MAIN", 0, "(%1.16f,%1.16f) ", creal(B.c[i + j*NG]), cimag(B.c[i + j*NG]));
+                lprintf("DEBUG", 2, "(%1.16f,%1.16f) ", creal(B.c[i + j*NG]), cimag(B.c[i + j*NG]));
             }
-            lprintf("MAIN", 0, "\n");
+            lprintf("DEBUG", 2, "\n");
         }
-        */        
+                
         
         for (int N1=0;N1<NG/2-1;N1++){
             for (int N2=N1+1;N2<NG/2;N2++){
-                //lprintf("MAIN", 0, "Cooling step %d, subgrb (%d,%d)\n", nbcool, N1, N2);
                 subgrb(N1, N2, &B, &S);
                 subgrb(NG/2 + N1, NG/2 + N2, &B, &S);
                 subgrb_tau( N1, N2, &B, &S);
@@ -523,9 +522,6 @@ void subgrb(int i1col, int i2col, suNgfull* B11, suNgfull* C11){
     
     i1 = i1col + i1col*NG;
     i2 = i2col + i2col*NG;
-
-    //i3 = i2col + i1col*NG;
-    //i4 = i1col + i2col*NG;
     
     i4 = i2col + i1col*NG;
     i3 = i1col + i2col*NG;
@@ -550,12 +546,9 @@ void subgrb(int i1col, int i2col, suNgfull* B11, suNgfull* C11){
     _complex_mulr(A11[3],  1., F11);
 
     // print the SU(2) matrix for debug
-
-    /*
-    lprintf("MAIN", 0, "Extracted SU(2) matrix:\n");
-    lprintf("MAIN", 0, "(%1.16f,%1.16f) (%1.16f,%1.16f)\n", creal(A11[0]), cimag(A11[0]), creal(A11[1]), cimag(A11[1]));
-    lprintf("MAIN", 0, "(%1.16f,%1.16f) (%1.16f,%1.16f)\n", creal(A11[2]), cimag(A11[2]), creal(A11[3]), cimag(A11[3]));
-    */
+    lprintf("DEBUG", 2, "Extracted SU(2) matrix:\n");
+    lprintf("DEBUG", 2, "(%1.16f,%1.16f) (%1.16f,%1.16f)\n", creal(A11[0]), cimag(A11[0]), creal(A11[1]), cimag(A11[1]));
+    lprintf("DEBUG", 2, "(%1.16f,%1.16f) (%1.16f,%1.16f)\n", creal(A11[2]), cimag(A11[2]), creal(A11[3]), cimag(A11[3]));
     
     vmxsu2(i1col,i2col,C11,A11);
     vmxsu2(i1col,i2col,B11,A11);
@@ -580,25 +573,16 @@ void vmxsu2(int i1, int i2, suNgfull* A, double complex B[4]){
     double complex ztmp1,ztmp2;
     
     for (int i=0; i<NG; i++){
-        //_complex_mul(ztmp1, A->c[i + i1*NG], B[0]);
-        //_complex_mul(ztmp2, A->c[i + i2*NG], B[2]);
-
         _complex_mul(ztmp1, A->c[i1 + i*NG], B[0]);
         _complex_mul(ztmp2, A->c[i2 + i*NG], B[2]);
         _complex_add(C[i], ztmp1, ztmp2);
         
-        //_complex_mul(ztmp1, A->c[i + i1*NG], B[1]);
-        //_complex_mul(ztmp2, A->c[i + i2*NG], B[3]);
-
         _complex_mul(ztmp1, A->c[i1 + i*NG], B[1]);
         _complex_mul(ztmp2, A->c[i2 + i*NG], B[3]);
         _complex_add(C[i+NG], ztmp1, ztmp2);
     }
     
     for (int i=0; i<NG; i++){
-        //A->c[i + i1*NG] = C[i];
-        //A->c[i + i2*NG] = C[i+NG];
-        //
         A->c[i1 + i*NG] = C[i]; 
         A->c[i2 + i*NG] = C[i+NG];
     }
@@ -626,8 +610,6 @@ void subgrb_tau(int n1, int n2, suNgfull* B11, suNgfull* C11){
     
     i1 = n1 + n1*NG;
     i2 = (NG/2) + n2 + (NG/2 + n2)*NG;
-    //i3 = NG/2 + n2 + n1*NG;
-    //i4 = (NG/2 + n2)*NG + n1;
 
     i4 = NG/2 + n2 + n1*NG;
     i3 = (NG/2 + n2)*NG + n1;
@@ -651,11 +633,9 @@ void subgrb_tau(int n1, int n2, suNgfull* B11, suNgfull* C11){
     _complex_mulr(A11[3],  1., F11);
 
     // print the SU(2) matrix for debug
-    /*
-    lprintf("MAIN", 0, "Extracted SU(2) tau matrix:\n");
-    lprintf("MAIN", 0, "(%1.16f,%1.16f) (%1.16f,%1.16f)\n", creal(A11[0]), cimag(A11[0]), creal(A11[1]), cimag(A11[1]));
-    lprintf("MAIN", 0, "(%1.16f,%1.16f) (%1.16f,%1.16f)\n", creal(A11[2]), cimag(A11[2]), creal(A11[3]), cimag(A11[3]));
-    */
+    lprintf("DEBUG", 2, "Extracted SU(2) tau matrix:\n");
+    lprintf("DEBUG", 2, "(%1.16f,%1.16f) (%1.16f,%1.16f)\n", creal(A11[0]), cimag(A11[0]), creal(A11[1]), cimag(A11[1]));
+    lprintf("DEBUG", 2, "(%1.16f,%1.16f) (%1.16f,%1.16f)\n", creal(A11[2]), cimag(A11[2]), creal(A11[3]), cimag(A11[3]));
 
     
     vmxsu2_tau(n1, n2, C11, A11);
@@ -685,30 +665,18 @@ void vmxsu2_tau(int n1, int n2, suNgfull* A, complex B[4]){
     
     for (int i=0; i<NG; i++){
         
-        //_complex_mul(ztmp1, A->c[i + n1*NG], B[0]);
-        //_complex_mul(ztmp2, A->c[i +(NG/2+n2)*NG], B[2]);
-        //_complex_add(C.c[i + n1*NG], ztmp1, ztmp2);
         _complex_mul(ztmp1, A->c[n1 + i*NG], B[0]);
         _complex_mul(ztmp2, A->c[(NG/2+n2) + i*NG], B[2]);
         _complex_add(C.c[n1 + i*NG], ztmp1, ztmp2);
         
-        //_complex_mul(ztmp1, A->c[i + n2*NG], B[0]);
-        //_complex_mul(ztmp2, A->c[i + (NG/2+n1)*NG], B[2]);
-        //_complex_add(C.c[i + n2*NG], ztmp1, ztmp2);
         _complex_mul(ztmp1, A->c[n2 + i*NG], B[0]);
         _complex_mul(ztmp2, A->c[(NG/2+n1) + i*NG], B[2]);
         _complex_add(C.c[n2 + i*NG], ztmp1, ztmp2);
         
-        //_complex_mul(ztmp1, A->c[i + n2*NG], B[1]);
-        //_complex_mul(ztmp2, A->c[i + (NG/2+n1)*NG], B[3]);
-        //_complex_add(C.c[i + (NG/2 + n1)*NG], ztmp1, ztmp2);
         _complex_mul(ztmp1, A->c[n2 + i*NG], B[1]);
         _complex_mul(ztmp2, A->c[(NG/2+n1) + i*NG], B[3]);
         _complex_add(C.c[(NG/2 + n1) + i*NG], ztmp1, ztmp2);
         
-        //_complex_mul(ztmp1, A->c[i + n1*NG], B[1]);
-        //_complex_mul(ztmp2, A->c[i + (NG/2+n2)*NG], B[3]);
-        //_complex_add(C.c[i + (NG/2 + n2)*NG], ztmp1, ztmp2);
         _complex_mul(ztmp1, A->c[n1 + i*NG], B[1]);
         _complex_mul(ztmp2, A->c[(NG/2+n2) + i*NG], B[3]);
         _complex_add(C.c[(NG/2 + n2) + i*NG], ztmp1, ztmp2);

--- a/LibHR/Utils/suN_utils.c
+++ b/LibHR/Utils/suN_utils.c
@@ -470,10 +470,23 @@ void cooling_SPN(suNg* g_out, suNg* g_in, suNg* g_tilde, int cooling){
     _suNg_expand( S, *g_in);
         
     for (int nbcool=0;nbcool<cooling;nbcool++){
-        _suNgfull_times_suNgfull_dagger(B, S, U_tilde);
+        //_suNgfull_times_suNgfull_dagger(B, S, U_tilde);
+        _suNgfull_dagger_times_suNgfull(B, U_tilde, S);
+        
+        //print the B matrix for debug
+        /*
+        lprintf("MAIN", 0, "Matrix B = S * U_tilde^dagger before cooling step %d:\n", nbcool);
+        for (int i=0;i<NG;i++){
+            for (int j=0;j<NG;j++){
+                lprintf("MAIN", 0, "(%1.16f,%1.16f) ", creal(B.c[i + j*NG]), cimag(B.c[i + j*NG]));
+            }
+            lprintf("MAIN", 0, "\n");
+        }
+        */        
         
         for (int N1=0;N1<NG/2-1;N1++){
             for (int N2=N1+1;N2<NG/2;N2++){
+                //lprintf("MAIN", 0, "Cooling step %d, subgrb (%d,%d)\n", nbcool, N1, N2);
                 subgrb(N1, N2, &B, &S);
                 subgrb(NG/2 + N1, NG/2 + N2, &B, &S);
                 subgrb_tau( N1, N2, &B, &S);
@@ -510,8 +523,12 @@ void subgrb(int i1col, int i2col, suNgfull* B11, suNgfull* C11){
     
     i1 = i1col + i1col*NG;
     i2 = i2col + i2col*NG;
-    i3 = i2col + i1col*NG;
-    i4 = i1col + i2col*NG;
+
+    //i3 = i2col + i1col*NG;
+    //i4 = i1col + i2col*NG;
+    
+    i4 = i2col + i1col*NG;
+    i3 = i1col + i2col*NG;
     
     _complex_add_star(F11, B11->c[i1], B11->c[i2]);
     _complex_mulr(F11, 0.5, F11);
@@ -531,6 +548,14 @@ void subgrb(int i1col, int i2col, suNgfull* B11, suNgfull* C11){
     _complex_star(A11[1], F12);
     _complex_mulr(A11[2], -1., F12);
     _complex_mulr(A11[3],  1., F11);
+
+    // print the SU(2) matrix for debug
+
+    /*
+    lprintf("MAIN", 0, "Extracted SU(2) matrix:\n");
+    lprintf("MAIN", 0, "(%1.16f,%1.16f) (%1.16f,%1.16f)\n", creal(A11[0]), cimag(A11[0]), creal(A11[1]), cimag(A11[1]));
+    lprintf("MAIN", 0, "(%1.16f,%1.16f) (%1.16f,%1.16f)\n", creal(A11[2]), cimag(A11[2]), creal(A11[3]), cimag(A11[3]));
+    */
     
     vmxsu2(i1col,i2col,C11,A11);
     vmxsu2(i1col,i2col,B11,A11);
@@ -555,18 +580,27 @@ void vmxsu2(int i1, int i2, suNgfull* A, double complex B[4]){
     double complex ztmp1,ztmp2;
     
     for (int i=0; i<NG; i++){
-        _complex_mul(ztmp1, A->c[i + i1*NG], B[0]);
-        _complex_mul(ztmp2, A->c[i + i2*NG], B[2]);
+        //_complex_mul(ztmp1, A->c[i + i1*NG], B[0]);
+        //_complex_mul(ztmp2, A->c[i + i2*NG], B[2]);
+
+        _complex_mul(ztmp1, A->c[i1 + i*NG], B[0]);
+        _complex_mul(ztmp2, A->c[i2 + i*NG], B[2]);
         _complex_add(C[i], ztmp1, ztmp2);
         
-        _complex_mul(ztmp1, A->c[i + i1*NG], B[1]);
-        _complex_mul(ztmp2, A->c[i + i2*NG], B[3]);
+        //_complex_mul(ztmp1, A->c[i + i1*NG], B[1]);
+        //_complex_mul(ztmp2, A->c[i + i2*NG], B[3]);
+
+        _complex_mul(ztmp1, A->c[i1 + i*NG], B[1]);
+        _complex_mul(ztmp2, A->c[i2 + i*NG], B[3]);
         _complex_add(C[i+NG], ztmp1, ztmp2);
     }
     
     for (int i=0; i<NG; i++){
-        A->c[i + i1*NG] = C[i];
-        A->c[i + i2*NG] = C[i+NG];
+        //A->c[i + i1*NG] = C[i];
+        //A->c[i + i2*NG] = C[i+NG];
+        //
+        A->c[i1 + i*NG] = C[i]; 
+        A->c[i2 + i*NG] = C[i+NG];
     }
 }
 
@@ -592,8 +626,11 @@ void subgrb_tau(int n1, int n2, suNgfull* B11, suNgfull* C11){
     
     i1 = n1 + n1*NG;
     i2 = (NG/2) + n2 + (NG/2 + n2)*NG;
-    i3 = NG/2 + n2 + n1*NG;
-    i4 = (NG/2 + n2)*NG + n1;
+    //i3 = NG/2 + n2 + n1*NG;
+    //i4 = (NG/2 + n2)*NG + n1;
+
+    i4 = NG/2 + n2 + n1*NG;
+    i3 = (NG/2 + n2)*NG + n1;
     
     _complex_add_star(F11, B11->c[i1], B11->c[i2]);
     _complex_mulr(F11, 0.5, F11);
@@ -612,6 +649,14 @@ void subgrb_tau(int n1, int n2, suNgfull* B11, suNgfull* C11){
     _complex_star(A11[1], F12);
     _complex_mulr(A11[2], -1., F12);
     _complex_mulr(A11[3],  1., F11);
+
+    // print the SU(2) matrix for debug
+    /*
+    lprintf("MAIN", 0, "Extracted SU(2) tau matrix:\n");
+    lprintf("MAIN", 0, "(%1.16f,%1.16f) (%1.16f,%1.16f)\n", creal(A11[0]), cimag(A11[0]), creal(A11[1]), cimag(A11[1]));
+    lprintf("MAIN", 0, "(%1.16f,%1.16f) (%1.16f,%1.16f)\n", creal(A11[2]), cimag(A11[2]), creal(A11[3]), cimag(A11[3]));
+    */
+
     
     vmxsu2_tau(n1, n2, C11, A11);
     vmxsu2_tau(n1, n2, B11, A11);
@@ -640,21 +685,33 @@ void vmxsu2_tau(int n1, int n2, suNgfull* A, complex B[4]){
     
     for (int i=0; i<NG; i++){
         
-        _complex_mul(ztmp1, A->c[i + n1*NG], B[0]);
-        _complex_mul(ztmp2, A->c[i +(NG/2+n2)*NG], B[2]);
-        _complex_add(C.c[i + n1*NG], ztmp1, ztmp2);
+        //_complex_mul(ztmp1, A->c[i + n1*NG], B[0]);
+        //_complex_mul(ztmp2, A->c[i +(NG/2+n2)*NG], B[2]);
+        //_complex_add(C.c[i + n1*NG], ztmp1, ztmp2);
+        _complex_mul(ztmp1, A->c[n1 + i*NG], B[0]);
+        _complex_mul(ztmp2, A->c[(NG/2+n2) + i*NG], B[2]);
+        _complex_add(C.c[n1 + i*NG], ztmp1, ztmp2);
         
-        _complex_mul(ztmp1, A->c[i + n2*NG], B[0]);
-        _complex_mul(ztmp2, A->c[i + (NG/2+n1)*NG], B[2]);
-        _complex_add(C.c[i + n2*NG], ztmp1, ztmp2);
+        //_complex_mul(ztmp1, A->c[i + n2*NG], B[0]);
+        //_complex_mul(ztmp2, A->c[i + (NG/2+n1)*NG], B[2]);
+        //_complex_add(C.c[i + n2*NG], ztmp1, ztmp2);
+        _complex_mul(ztmp1, A->c[n2 + i*NG], B[0]);
+        _complex_mul(ztmp2, A->c[(NG/2+n1) + i*NG], B[2]);
+        _complex_add(C.c[n2 + i*NG], ztmp1, ztmp2);
         
-        _complex_mul(ztmp1, A->c[i + n2*NG], B[1]);
-        _complex_mul(ztmp2, A->c[i + (NG/2+n1)*NG], B[3]);
-        _complex_add(C.c[i + (NG/2 + n1)*NG], ztmp1, ztmp2);
+        //_complex_mul(ztmp1, A->c[i + n2*NG], B[1]);
+        //_complex_mul(ztmp2, A->c[i + (NG/2+n1)*NG], B[3]);
+        //_complex_add(C.c[i + (NG/2 + n1)*NG], ztmp1, ztmp2);
+        _complex_mul(ztmp1, A->c[n2 + i*NG], B[1]);
+        _complex_mul(ztmp2, A->c[(NG/2+n1) + i*NG], B[3]);
+        _complex_add(C.c[(NG/2 + n1) + i*NG], ztmp1, ztmp2);
         
-        _complex_mul(ztmp1, A->c[i + n1*NG], B[1]);
-        _complex_mul(ztmp2, A->c[i + (NG/2+n2)*NG], B[3]);
-        _complex_add(C.c[i + (NG/2 + n2)*NG], ztmp1, ztmp2);
+        //_complex_mul(ztmp1, A->c[i + n1*NG], B[1]);
+        //_complex_mul(ztmp2, A->c[i + (NG/2+n2)*NG], B[3]);
+        //_complex_add(C.c[i + (NG/2 + n2)*NG], ztmp1, ztmp2);
+        _complex_mul(ztmp1, A->c[n1 + i*NG], B[1]);
+        _complex_mul(ztmp2, A->c[(NG/2+n2) + i*NG], B[3]);
+        _complex_add(C.c[(NG/2 + n2) + i*NG], ztmp1, ztmp2);
     }
     _suNgfull_mul(*A, 1., C);
 }


### PR DESCRIPTION
I updated the `cooling_SPN` routine to perfectly replicate the behavior of the old Fortran 90 code. Both versions are mathematically equivalent, but they yield slightly different numerical results due to implementation details.

Specifically, the differences are:

1. In equation (25) of [https://arxiv.org/pdf/hep-lat/0404008](https://arxiv.org/pdf/hep-lat/0404008), one can pick either the row or columnGram-Schmidt orthogonalized link `U_b` for the first iteration of the cooling algorithm.
   - The F90 code orthogonalizes the columns
   - The `spn_smearing` branch orthogonalizes the rows.

2. In the same equation, the link `U_b` is updated via multiplication with an SU(2) subgroup matrix `A`. This can be done via either left or right multiplication.
   - The F90 code performs the update as: `U_b → U_b * A`.
   - The `spn_smearing` branch performs the update as: `U_b → Aᵗ * U_b`.
